### PR TITLE
Can't override main when no main is specified in source bower.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var loadConfigJson = function(dependencyConfig) {
 
     var json = JSON.parse(fs.readFileSync(jsonPath))
 
-    if(!json.main){
+    if(!json.main&&!dependencyConfig.main){
         throw new PluginError(PLUGIN_NAME, "The bower package " + dependencyConfig.name + " has no main file(s), use the overrides property in your bower.json");
     }
     


### PR DESCRIPTION
Because the exception is thrown on the basis of the contents of the original bower.json without consideration of the overrides config.

By checking dependencyConfig.main prior to throwing the exception we can proceed safely.
