### PR TITLE
Fix crash when collecting devDependencies

### DIFF
--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -57,16 +57,17 @@ PackageCollection.prototype = {
             throw new Error("bower.json does not exists at: " + this.opts.paths.bowerJson);
 
         var bowerJson = JSON.parse(fs.readFileSync(this.opts.paths.bowerJson, "utf8"));
+        var dependencies = bowerJson.dependencies || {};
 
         this.overrides = bowerJson.overrides || {};
 
         if(this.opts.includeDev === true && bowerJson.devDependencies) {
             for(var name in bowerJson.devDependencies) {
-                bowerJson.dependencies[name] = bowerJson.devDependencies[name]
+                dependencies[name] = bowerJson.devDependencies[name];
             }
         }
 
-        for(var name in bowerJson.dependencies) {
+        for(var name in dependencies) {
             this.add(name, path.join(this.opts.paths.bowerDirectory, "/", name));
         }
     },

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -54,7 +54,7 @@ PackageCollection.prototype = {
      */
     collectPackages: function() {
         if(!fs.existsSync(this.opts.paths.bowerJson))
-            throw new Error("bower.json does not exists at: " + this.opts.paths.bowerJson);
+            throw new Error("bower.json does not exist at: " + this.opts.paths.bowerJson);
 
         var bowerJson = JSON.parse(fs.readFileSync(this.opts.paths.bowerJson, "utf8"));
         var dependencies = bowerJson.dependencies || {};

--- a/test/_includedev_devdepsonly_bower.json
+++ b/test/_includedev_devdepsonly_bower.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "includeDev": "*"
+    }
+}

--- a/test/main.js
+++ b/test/main.js
@@ -112,6 +112,12 @@ describe('gulpBowerFiles()', function () {
         ]).fromConfig("/_includedev_bower.json", { includeDev: true }).when(done);    
     });
 
+    it("should get devDependencies from a bower.json with no 'dependencies' section", function(done) {
+        expect([
+            "/fixtures/includeDev/includeDev.js"
+        ]).fromConfig("/_includedev_devdepsonly_bower.json", { includeDev: true }).when(done);    
+    });
+
     it("should not load any deeper dependencies", function(done) {
         expect([
             "/fixtures/recursive/recursive.js"


### PR DESCRIPTION
With the includeDev option set and the following bower.json given:

```
{
    "name": "foo",
    "devDependencies": {
        "mocha": "*"
    }
}
```

gulp dies with `Cannot set property 'mocha' of undefined`.

This is because the current code expects a `dependencies` section to be
provided in bower.json and tries to push `devDependencies` into it. This
patch gives it a default of `{}`.
