### PR TITLE
Accept a String in opts.paths as a basepath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If `process.env.NODE_ENV` is not set you can use this option.
 
 #### paths
 
-Type: `Object`
+Type: `Object` or `String`
 
 You can specify the paths where the following bower specific files are located:
 `bower_components`, `.bowerrc` and `bower.json`
@@ -123,6 +123,23 @@ bowerFiles({
     }
 })
 .pipe(gulp.dest('client/src/lib'));
+```
+
+If a `String` is supplied instead, it will become the basepath for default paths.
+
+For example:
+
+```javascript
+bowerFiles({ paths: 'path/for/project' })
+.pipe(gulp.dest('client/src/lib'));
+
+/*
+    {
+        bowerDirectory: 'path/for/project/bower_components',
+        bowerrc: 'path/for/project/.bowerrc',
+        bowerJson: 'path/for/project/bower.json'
+    }
+*/
 ```
 
 #### checkExistence

--- a/index.js
+++ b/index.js
@@ -11,12 +11,26 @@ const PLUGIN_NAME = "gulp-bower-files";
 module.exports = function(opts){
     opts = opts || {};
 
+    var defaults = {
+        paths: {
+            bowerJson     : "./bower.json",
+            bowerrc       : "./.bowerrc",
+            bowerDirectory: "./bower_components"
+        }
+    }
+
     if(!opts.paths)
         opts.paths = {}
 
-    opts.paths.bowerJson        = opts.paths.bowerJson || "./bower.json";
-    opts.paths.bowerrc          = opts.paths.bowerrc || "./.bowerrc";
-    opts.paths.bowerDirectory   = opts.paths.bowerDirectory || "./bower_components";
+    if(typeof opts.paths === 'string'){
+        opts.paths.bowerJson        = path.join(opts.paths, defaults.paths.bowerJson)
+        opts.paths.bowerrc          = path.join(opts.paths, defaults.paths.bowerrc)
+        opts.paths.bowerDirectory   = path.join(opts.paths, defaults.paths.bowerDirectory)
+    }
+
+    opts.paths.bowerJson        = opts.paths.bowerJson      || defaults.paths.bowerJson;
+    opts.paths.bowerrc          = opts.paths.bowerrc        || defaults.paths.bowerrc;
+    opts.paths.bowerDirectory   = opts.paths.bowerDirectory || defaults.paths.bowerDirectory;
 
     if(fs.existsSync(opts.paths.bowerrc)){
         opts.paths.bowerDirectory = path.dirname(opts.paths.bowerrc);


### PR DESCRIPTION
If a `String` is supplied instead, it will become the basepath for default paths.

For example:

``` javascript
bowerFiles({ paths: 'path/for/project' })
.pipe(gulp.dest('client/src/lib'));

/*
    {
        bowerDirectory: 'path/for/project/bower_components',
        bowerrc: 'path/for/project/.bowerrc',
        bowerJson: 'path/for/project/bower.json'
    }
*/
```
